### PR TITLE
fix: harden compose input handling and project scope

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - id: list
         name: Collect .bats files
@@ -40,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup jq
         uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -13,7 +13,7 @@ jobs:
       files: ${{ steps.list.outputs.files }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - id: list
         name: Collect .bats files
@@ -39,14 +39,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup jq
-        uses: dcarbone/install-jq-action@v4
+        uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4
 
       - name: Setup Bats and bats libs
         id: setup-bats
-        uses: bats-core/bats-action@4.0.0
+        uses: bats-core/bats-action@5b1e60c2ee94cb1b44a616ea4b1f466f9d6e38ef # 4.0.0
         with:
           support-path: "${{ github.workspace }}/tests/bats-support"
           assert-path: "${{ github.workspace }}/tests/bats-assert"
@@ -84,7 +84,7 @@ jobs:
           echo "safe_name=$SAFE" >> "$GITHUB_OUTPUT"
 
       - name: Upload JUnit report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: junit-report-${{ steps.meta.outputs.safe_name }}-${{ github.run_attempt }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: 🔨Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: 🔬Check repository through Prettier
         uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0 # v4.6
         with:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: 🔨Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: 📦Download artifacts (all junit-report-*)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -49,6 +51,8 @@ jobs:
     steps:
       - name: 🔨Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Build Shields endpoint JSON (passed/failed/skipped)
         run: |

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -44,15 +44,11 @@ jobs:
   badge:
     name: "Publish badge (main only)"
     needs: summary
-    if: >
-      ${{
-        github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_branch == 'main'
-      }}
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: 🔨Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build Shields endpoint JSON (passed/failed/skipped)
         run: |
@@ -91,7 +87,7 @@ jobs:
           cat public/tests.json
 
       - name: Publish badge to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: public

--- a/action.yml
+++ b/action.yml
@@ -79,18 +79,25 @@ runs:
         DOCKER_HEALTH_PROJECT_NAME_INPUT: ${{ inputs.compose-project-name }}
         DOCKER_HEALTH_AUTO_APPLY_PROJECT_NAME: ${{ inputs.auto-apply-project-name }}
         DOCKER_HEALTH_PROJECT_ENV_FILE: ${{ inputs.project-name-env-file }}
+        COMPOSE_FILES_INPUT: ${{ inputs.compose-files }}
+        ADDITIONAL_COMPOSE_ARGS_INPUT: ${{ inputs.additional-compose-args }}
+        SERVICES_INPUT: ${{ inputs.services }}
+        COMPOSE_SERVICES_INPUT: ${{ inputs.compose-services }}
+        REPORT_FORMAT_INPUT: ${{ inputs.report-format }}
+        DOCKER_COMMAND_INPUT: ${{ inputs.docker-command }}
+        COMPOSE_PROFILES_INPUT: ${{ inputs.compose-profiles }}
       run: |
         set -euo pipefail
 
         SCRIPT_DIR="${GITHUB_ACTION_PATH}"
 
-        compose_files_input="${{ inputs.compose-files }}"
-        additional_args_input="${{ inputs.additional-compose-args }}"
-        services_input="${{ inputs.services }}"
-        compose_services_input="${{ inputs.compose-services }}"
-        report_format_input="${{ inputs.report-format }}"
-        docker_command_input="${{ inputs.docker-command }}"
-        compose_profiles_input="${{ inputs.compose-profiles }}"
+        compose_files_input="${COMPOSE_FILES_INPUT}"
+        additional_args_input="${ADDITIONAL_COMPOSE_ARGS_INPUT}"
+        services_input="${SERVICES_INPUT}"
+        compose_services_input="${COMPOSE_SERVICES_INPUT}"
+        report_format_input="${REPORT_FORMAT_INPUT}"
+        docker_command_input="${DOCKER_COMMAND_INPUT}"
+        compose_profiles_input="${COMPOSE_PROFILES_INPUT}"
 
         services_to_use="$compose_services_input"
         if [[ -z "$services_to_use" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/logging.sh"
+source "$SCRIPT_DIR/lib/parse-compose-services.sh"
 
 DOCKER_HEALTH_TIMEOUT="${DOCKER_HEALTH_TIMEOUT:-120}"
 DOCKER_HEALTH_LOG_LINES="${DOCKER_HEALTH_LOG_LINES:-25}"
@@ -689,47 +690,9 @@ execute() {
   local -a cmd_args=("$@")
 
   local -a services_from_cmd=()
-  local -a profile_args_post=()
-  local i token
-  local up_index=-1
 
-  for ((i = 0; i < ${#cmd_args[@]}; i++)); do
-    if [[ "${cmd_args[i]}" == "up" ]]; then
-      up_index=$i
-      break
-    fi
-  done
-
-  if ((up_index >= 0)); then
-    for ((i = up_index + 1; i < ${#cmd_args[@]}; i++)); do
-      token="${cmd_args[i]}"
-      [[ "$token" == "--" ]] && break
-      case "$token" in
-        --profile)
-          if ((i + 1 < ${#cmd_args[@]})) && [[ "${cmd_args[i + 1]}" != -* ]]; then
-            profile_args_post+=(--profile "${cmd_args[i + 1]}")
-            i=$((i + 1))
-          fi
-          continue
-          ;;
-        --profile=*)
-          profile_args_post+=(--profile "${token#--profile=}")
-          continue
-          ;;
-        -p)
-          if ((i + 1 < ${#cmd_args[@]})) && [[ "${cmd_args[i + 1]}" != -* ]]; then
-            profile_args_post+=(-p "${cmd_args[i + 1]}")
-            i=$((i + 1))
-          fi
-          continue
-          ;;
-      esac
-      if [[ "$token" == -* ]]; then
-        continue
-      fi
-      services_from_cmd+=("$token")
-    done
-  fi
+  collect_compose_services_from_up "${cmd_args[@]}"
+  services_from_cmd=("${COMPOSE_SERVICES_FROM_CMD[@]}")
 
   if ((${#services_from_cmd[@]} > 0)); then
     DOCKER_SERVICES_LIST="${services_from_cmd[*]}"
@@ -744,10 +707,6 @@ execute() {
     fi
     compose_base_cmd+=("${cmd_args[j]}")
   done
-
-  if ((${#profile_args_post[@]} > 0)); then
-    compose_base_cmd+=("${profile_args_post[@]}")
-  fi
 
   local compose_rc=0 tmp_out
   tmp_out="$(mktemp)"
@@ -779,19 +738,9 @@ execute() {
     rm -f "$tmp_out"
 
     echo
-    info "--- docker compose ps --all ---"
+    info "--- docker compose ps --all (current project) ---"
     echo "─────────────────────────────────────────────────────────────"
-    docker compose ps --all 2>/dev/null || true
-    echo
-
-    info "--- docker compose ls (all projects) ---"
-    echo "─────────────────────────────────────────────────────────────"
-    docker compose ls 2>/dev/null || true
-    echo
-
-    info "--- docker ps --all (global) ---"
-    echo "─────────────────────────────────────────────────────────────"
-    docker ps --all --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}' || true
+    "${compose_base_cmd[@]}" ps --all 2>/dev/null || true
     echo
     echo "─────────────────────────────────────────────────────────────"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,8 @@ DOCKER_HEALTH_LOG_LINES="${DOCKER_HEALTH_LOG_LINES:-25}"
 DOCKER_HEALTH_PROJECT_NAME_INPUT="${DOCKER_HEALTH_PROJECT_NAME_INPUT:-}"
 DOCKER_HEALTH_AUTO_APPLY_PROJECT_NAME="${DOCKER_HEALTH_AUTO_APPLY_PROJECT_NAME:-}"
 DOCKER_HEALTH_PROJECT_ENV_FILE="${DOCKER_HEALTH_PROJECT_ENV_FILE:-system.env}"
+# Diagnostics are fail-closed until Compose resolves an exact project name.
+DOCKER_HEALTH_PROJECT_SCOPE="${COMPOSE_PROJECT_NAME:-}"
 
 # Report format: text | json | both
 DOCKER_HEALTH_REPORT_FORMAT="${DOCKER_HEALTH_REPORT_FORMAT:-text}"
@@ -266,12 +268,9 @@ docker_health_add_unhealthy_target() {
 collect_compose_failed_targets() {
   local services="$1"
 
-  [[ -n "$services" ]] || return 0
+  [[ -n "$services" && -n "${DOCKER_HEALTH_PROJECT_SCOPE:-}" ]] || return 0
 
-  local -a project_filter=()
-  if [[ -n "${COMPOSE_PROJECT_NAME:-}" ]]; then
-    project_filter+=(--filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}")
-  fi
+  local -a project_filter=(--filter "label=com.docker.compose.project=${DOCKER_HEALTH_PROJECT_SCOPE}")
 
   local service cid state exit_code health
   while IFS= read -r service; do
@@ -421,8 +420,13 @@ check_service_health() {
   local interval_c=2
 
   local -a project_filter=()
-  if [[ -n "${COMPOSE_PROJECT_NAME:-}" ]]; then
-    project_filter+=(--filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}")
+  if [[ -n "${DOCKER_HEALTH_PROJECT_SCOPE:-}" ]]; then
+    project_filter+=(--filter "label=com.docker.compose.project=${DOCKER_HEALTH_PROJECT_SCOPE}")
+  else
+    warning "Cannot inspect service '$service' without a resolved Compose project; marking as 'No containers'."
+    ((no_containers_count++))
+    ((services_checked++))
+    return 1
   fi
 
   while :; do
@@ -516,10 +520,12 @@ check_service_health() {
 get_service_runtime_tag() {
   local service="$1"
 
-  local -a project_filter=()
-  if [[ -n "${COMPOSE_PROJECT_NAME:-}" ]]; then
-    project_filter+=(--filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}")
-  fi
+  [[ -n "${DOCKER_HEALTH_PROJECT_SCOPE:-}" ]] || {
+    echo "NO_CONTAINERS"
+    return 0
+  }
+
+  local -a project_filter=(--filter "label=com.docker.compose.project=${DOCKER_HEALTH_PROJECT_SCOPE}")
 
   local -a cids=()
   while IFS= read -r cid; do
@@ -718,6 +724,7 @@ execute() {
 
     local resolved_project=""
     resolved_project="$(resolve_project_name "${compose_base_cmd[@]}")"
+    DOCKER_HEALTH_PROJECT_SCOPE="$resolved_project"
     persist_project_name "$resolved_project"
 
     echo
@@ -780,6 +787,7 @@ execute() {
 
   local resolved_project=""
   resolved_project="$(resolve_project_name "${compose_base_cmd[@]}")"
+  DOCKER_HEALTH_PROJECT_SCOPE="$resolved_project"
   persist_project_name "$resolved_project"
 
   local -a cfg_cmd=("${compose_base_cmd[@]}" config --services)
@@ -831,4 +839,6 @@ execute() {
   echo "Application started successfully!"
 }
 
-execute "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  execute "$@"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,7 +77,7 @@ resolve_project_name() {
 
 get_explicit_project_name() {
   local -a compose_cmd=("$@")
-  local i token
+  local i token resolved_project=""
 
   for ((i = 0; i < ${#compose_cmd[@]}; i++)); do
     token="${compose_cmd[i]}"
@@ -85,16 +85,20 @@ get_explicit_project_name() {
     case "$token" in
       -p|--project-name)
         if ((i + 1 < ${#compose_cmd[@]})); then
-          printf '%s\n' "${compose_cmd[i + 1]}"
-          return 0
+          resolved_project="${compose_cmd[i + 1]}"
+          i=$((i + 1))
         fi
         ;;
       --project-name=*)
-        printf '%s\n' "${token#*=}"
-        return 0
+        resolved_project="${token#*=}"
         ;;
     esac
   done
+
+  if [[ -n "$resolved_project" ]]; then
+    printf '%s\n' "$resolved_project"
+  fi
+  return 0
 }
 
 persist_project_name() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,7 @@ get_repo_basename() {
 resolve_project_name() {
   local -a compose_cmd=("$@")
   local resolved_project=""
+  local resolved_from_command=""
   local resolved_from_compose=""
   local auto_apply=0
 
@@ -53,18 +54,47 @@ resolve_project_name() {
     auto_apply=1
   fi
 
-  resolved_from_compose="$(get_compose_project_name "${compose_cmd[@]}")"
-  if [[ -n "$resolved_from_compose" ]]; then
-    resolved_project="$resolved_from_compose"
-  elif [[ -n "$DOCKER_HEALTH_PROJECT_NAME_INPUT" ]]; then
-    resolved_project="$DOCKER_HEALTH_PROJECT_NAME_INPUT"
-  elif [[ -n "${COMPOSE_PROJECT_NAME:-}" ]]; then
-    resolved_project="$COMPOSE_PROJECT_NAME"
-  elif ((auto_apply == 1)); then
-    resolved_project="$(get_repo_basename)"
+  # A project flag on the command being executed is authoritative. Resolve it
+  # before querying Compose so diagnostics cannot fall back to another source
+  # while the project has no containers (or no project label) yet.
+  resolved_from_command="$(get_explicit_project_name "${compose_cmd[@]}")"
+  if [[ -n "$resolved_from_command" ]]; then
+    resolved_project="$resolved_from_command"
+  elif resolved_from_compose="$(get_compose_project_name "${compose_cmd[@]}")"; then
+    if [[ -n "$resolved_from_compose" ]]; then
+      resolved_project="$resolved_from_compose"
+    elif [[ -n "$DOCKER_HEALTH_PROJECT_NAME_INPUT" ]]; then
+      resolved_project="$DOCKER_HEALTH_PROJECT_NAME_INPUT"
+    elif [[ -n "${COMPOSE_PROJECT_NAME:-}" ]]; then
+      resolved_project="$COMPOSE_PROJECT_NAME"
+    elif ((auto_apply == 1)); then
+      resolved_project="$(get_repo_basename)"
+    fi
   fi
 
   echo "$resolved_project"
+}
+
+get_explicit_project_name() {
+  local -a compose_cmd=("$@")
+  local i token
+
+  for ((i = 0; i < ${#compose_cmd[@]}; i++)); do
+    token="${compose_cmd[i]}"
+    [[ "$token" == "--" ]] && break
+    case "$token" in
+      -p|--project-name)
+        if ((i + 1 < ${#compose_cmd[@]})); then
+          printf '%s\n' "${compose_cmd[i + 1]}"
+          return 0
+        fi
+        ;;
+      --project-name=*)
+        printf '%s\n' "${token#*=}"
+        return 0
+        ;;
+    esac
+  done
 }
 
 persist_project_name() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -176,6 +176,11 @@ get_compose_project_name() {
     fi
     echo "$project_label"
   fi
+
+  # No containers is a valid pre-start/zero-scale state. Return an empty
+  # project name successfully so resolve_project_name can apply its ordered,
+  # exact-project fallbacks instead of skipping them.
+  return 0
 }
 
 apply_explicit_project_name_input() {

--- a/lib/parse-compose-services.sh
+++ b/lib/parse-compose-services.sh
@@ -28,11 +28,11 @@ collect_compose_services_from_up() {
     # These up options consume the following token. Keep this list explicit
     # so option operands (notably --scale's SERVICE=NUM) cannot become targets.
     case "$token" in
-      --scale|--profile|-p|--project-name|--pull|--timeout|--wait-timeout|--exit-code-from|--attach|--stop-timeout)
+      --scale|--profile|-p|--project-name|--pull|--timeout|--wait-timeout|--exit-code-from|--attach|--no-attach|--stop-timeout)
         ((i + 1 < ${#cmd_args[@]})) && ((i++))
         continue
         ;;
-      --scale=*|--profile=*|--project-name=*|--pull=*|--timeout=*|--wait-timeout=*|--exit-code-from=*|--attach=*|--stop-timeout=*)
+      --scale=*|--profile=*|--project-name=*|--pull=*|--timeout=*|--wait-timeout=*|--exit-code-from=*|--attach=*|--no-attach=*|--stop-timeout=*)
         continue
         ;;
     esac

--- a/lib/parse-compose-services.sh
+++ b/lib/parse-compose-services.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Parse service operands from a docker compose up command without executing it.
+# The result is returned in COMPOSE_SERVICES_FROM_CMD as an array.
+collect_compose_services_from_up() {
+  local -a cmd_args=("$@")
+  COMPOSE_SERVICES_FROM_CMD=()
+  local i token up_index=-1
+
+  for ((i = 0; i < ${#cmd_args[@]}; i++)); do
+    if [[ "${cmd_args[i]}" == "up" ]]; then
+      up_index=$i
+      break
+    fi
+  done
+  ((up_index >= 0)) || return 0
+
+  for ((i = up_index + 1; i < ${#cmd_args[@]}; i++)); do
+    token="${cmd_args[i]}"
+    if [[ "$token" == "--" ]]; then
+      ((i++))
+      while ((i < ${#cmd_args[@]})); do
+        COMPOSE_SERVICES_FROM_CMD+=("${cmd_args[i]}")
+        ((i++))
+      done
+      break
+    fi
+
+    # These up options consume the following token. Keep this list explicit
+    # so option operands (notably --scale's SERVICE=NUM) cannot become targets.
+    case "$token" in
+      --scale|--profile|-p|--project-name|--pull|--timeout|--wait-timeout|--exit-code-from|--attach|--stop-timeout)
+        ((i + 1 < ${#cmd_args[@]})) && ((i++))
+        continue
+        ;;
+      --scale=*|--profile=*|--project-name=*|--pull=*|--timeout=*|--wait-timeout=*|--exit-code-from=*|--attach=*|--stop-timeout=*)
+        continue
+        ;;
+    esac
+    [[ "$token" == -* ]] && continue
+    COMPOSE_SERVICES_FROM_CMD+=("$token")
+  done
+}

--- a/lib/parse-compose-services.sh
+++ b/lib/parse-compose-services.sh
@@ -28,7 +28,7 @@ collect_compose_services_from_up() {
     # These up options consume the following token. Keep this list explicit
     # so option operands (notably --scale's SERVICE=NUM) cannot become targets.
     case "$token" in
-      --scale|--profile|-p|--project-name|--pull|--timeout|--wait-timeout|--exit-code-from|--attach|--no-attach|--stop-timeout)
+      --scale|--profile|-p|--project-name|--pull|-t|--timeout|--wait-timeout|--exit-code-from|--attach|--no-attach|--stop-timeout)
         ((i + 1 < ${#cmd_args[@]})) && ((i++))
         continue
         ;;

--- a/tests/unit/action_inputs.bats
+++ b/tests/unit/action_inputs.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+@test "composite action does not interpolate inputs inside run source" {
+  action="$BATS_TEST_DIRNAME/../../action.yml"
+  run awk '/^      run: \|/ { in_run=1; next } in_run && /\$\{\{ inputs\./ { found=1 } END { exit found ? 1 : 0 }' "$action"
+  [ "$status" -eq 0 ]
+}
+
+@test "all shell-consumed public inputs have stable env mappings" {
+  action="$BATS_TEST_DIRNAME/../../action.yml"
+  for name in compose-files additional-compose-args services compose-services report-format docker-command compose-profiles; do
+    env_name="$(printf '%s' "$name" | tr '[:lower:]-' '[:upper:]_')_INPUT"
+    grep -F "$env_name: \${{ inputs.$name }}" "$action"
+  done
+}
+
+@test "payload metacharacters remain data in shell variables" {
+  payload='$(touch /tmp/compose-health-check-action-payload) `touch /tmp/compose-health-check-action-backtick` "quoted"'
+  marker="$(mktemp)"
+  run bash -c 'value="$1"; printf "%s" "$value" > "$2"' _ "$payload" "$marker"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$marker")" = "$payload" ]
+  [ ! -e /tmp/compose-health-check-action-payload ]
+  [ ! -e /tmp/compose-health-check-action-backtick ]
+  rm -f "$marker"
+}

--- a/tests/unit/action_inputs.bats
+++ b/tests/unit/action_inputs.bats
@@ -14,13 +14,14 @@
   done
 }
 
-@test "payload metacharacters remain data in shell variables" {
-  payload='$(touch /tmp/compose-health-check-action-payload) `touch /tmp/compose-health-check-action-backtick` "quoted"'
+@test "build command transports shell metacharacters as data" {
   marker="$(mktemp)"
-  run bash -c 'value="$1"; printf "%s" "$value" > "$2"' _ "$payload" "$marker"
-  [ "$status" -eq 0 ]
-  [ "$(cat "$marker")" = "$payload" ]
-  [ ! -e /tmp/compose-health-check-action-payload ]
-  [ ! -e /tmp/compose-health-check-action-backtick ]
   rm -f "$marker"
+  payload="$(printf 'docker compose --project-name \"$(touch %s)\" up -d \"web`touch %s`\" \"quote \\\" newline\nservice\"' "$marker" "$marker")"
+  run bash -c 'mapfile -d "" -t cmd < <(DOCKER_COMMAND_INPUT="$1" bash "$2"); printf "%s\\n" "${cmd[@]}"' _ "$payload" "$BATS_TEST_DIRNAME/../../lib/build-compose-command.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'$(touch '* ]]
+  [[ "$output" == *'`touch '* ]]
+  [[ "$output" == *$'newline\nservice'* ]]
+  [ ! -e "$marker" ]
 }

--- a/tests/unit/compose_services.bats
+++ b/tests/unit/compose_services.bats
@@ -24,6 +24,12 @@
   [[ "${COMPOSE_SERVICES_FROM_CMD[*]}" == "web" ]]
 }
 
+@test "short timeout option operand does not become a service" {
+  source "$BATS_TEST_DIRNAME/../../lib/parse-compose-services.sh"
+  collect_compose_services_from_up docker compose up -t 30 web
+  [[ "${COMPOSE_SERVICES_FROM_CMD[*]}" == "web" ]]
+}
+
 @test "explicit boundary preserves service-like option names" {
   source "$BATS_TEST_DIRNAME/../../lib/parse-compose-services.sh"
   collect_compose_services_from_up docker compose up -- --service-with-dash web

--- a/tests/unit/compose_services.bats
+++ b/tests/unit/compose_services.bats
@@ -18,6 +18,12 @@
   [[ "${#COMPOSE_SERVICES_FROM_CMD[@]}" -eq 0 ]]
 }
 
+@test "operand-taking no-attach option does not become a service" {
+  source "$BATS_TEST_DIRNAME/../../lib/parse-compose-services.sh"
+  collect_compose_services_from_up docker compose up --no-attach worker web
+  [[ "${COMPOSE_SERVICES_FROM_CMD[*]}" == "web" ]]
+}
+
 @test "explicit boundary preserves service-like option names" {
   source "$BATS_TEST_DIRNAME/../../lib/parse-compose-services.sh"
   collect_compose_services_from_up docker compose up -- --service-with-dash web

--- a/tests/unit/compose_services.bats
+++ b/tests/unit/compose_services.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+@test "scaled compose up parses service after --scale operand" {
+  source "$BATS_TEST_DIRNAME/../../lib/parse-compose-services.sh"
+  collect_compose_services_from_up docker compose --profile default -p project up -d --scale web=2 web
+  [[ "${COMPOSE_SERVICES_FROM_CMD[*]}" == "web" ]]
+}
+
+@test "equals scale and project/profile options do not become services" {
+  source "$BATS_TEST_DIRNAME/../../lib/parse-compose-services.sh"
+  collect_compose_services_from_up docker compose --profile=default --project-name=project up --scale=web=2 --wait-timeout 30 web api
+  [[ "${COMPOSE_SERVICES_FROM_CMD[*]}" == "web api" ]]
+}
+
+@test "scale without explicit service leaves auto-discovery to compose config" {
+  source "$BATS_TEST_DIRNAME/../../lib/parse-compose-services.sh"
+  collect_compose_services_from_up docker compose -p project up --scale web=2 --
+  [[ "${#COMPOSE_SERVICES_FROM_CMD[@]}" -eq 0 ]]
+}
+
+@test "explicit boundary preserves service-like option names" {
+  source "$BATS_TEST_DIRNAME/../../lib/parse-compose-services.sh"
+  collect_compose_services_from_up docker compose up -- --service-with-dash web
+  [[ "${COMPOSE_SERVICES_FROM_CMD[*]}" == "--service-with-dash web" ]]
+}

--- a/tests/unit/project_scope.bats
+++ b/tests/unit/project_scope.bats
@@ -46,3 +46,38 @@
   [ "$output" = "NO_CONTAINERS" ]
   [[ "$output" != *"unexpected docker call"* ]]
 }
+
+@test "explicit command project wins over input when compose has no label" {
+  marker="$(mktemp)"
+  rm -f "$marker"
+  docker() {
+    printf '%s\n' "$*" >>"$marker"
+    case "$1" in
+      info) printf 'linux/amd64\n' ;;
+      ps)
+        if [[ "$*" == *'label=com.docker.compose.project=target'* ]]; then
+          printf '\n'
+        else
+          printf 'foreigncid\n'
+        fi
+        ;;
+    esac
+  }
+  DOCKER_HEALTH_PROJECT_NAME_INPUT="foreign"
+  COMPOSE_PROJECT_NAME="foreign"
+  source "$BATS_TEST_DIRNAME/../../entrypoint.sh"
+
+  for variant in '-p target' '--project-name target' '--project-name=target'; do
+    read -r -a command <<<"docker compose $variant up -d web"
+    run resolve_project_name "${command[@]}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "target" ]
+  done
+
+  DOCKER_HEALTH_PROJECT_SCOPE="$output"
+  run get_service_runtime_tag web
+  [ "$status" -eq 0 ]
+  [ "$output" = "NO_CONTAINERS" ]
+  ! grep -F 'foreign' "$marker" >/dev/null
+  rm -f "$marker"
+}

--- a/tests/unit/project_scope.bats
+++ b/tests/unit/project_scope.bats
@@ -33,7 +33,7 @@
   [ "$status" -eq 0 ]
   [ "$output" = "HEALTHY" ]
   grep -F 'label=com.docker.compose.project=target-project' "$marker"
-  ! grep -F 'label=com.docker.compose.service=web' "$marker" >/dev/null || true
+  grep -F 'label=com.docker.compose.service=web' "$marker"
   rm -f "$marker"
 }
 

--- a/tests/unit/project_scope.bats
+++ b/tests/unit/project_scope.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+@test "runtime lookup scopes same-named service to resolved project" {
+  marker="$(mktemp)"
+  rm -f "$marker"
+  docker() {
+    printf '%s\n' "$*" >>"$marker"
+    case "$1" in
+      info)
+        printf 'linux/amd64\n'
+        ;;
+      ps)
+        if [[ "$*" == *'target-project'* ]]; then
+          printf 'targetcid\n'
+        else
+          printf 'foreigncid\n'
+        fi
+        ;;
+      inspect)
+        if [[ "$*" == *targetcid* ]]; then
+          case "$*" in
+            *Health.Status*) printf 'healthy\n' ;;
+            *Health\}\}*) printf 'yes\n' ;;
+            *Status*) printf 'running\n' ;;
+          esac
+        fi
+        ;;
+    esac
+  }
+  source "$BATS_TEST_DIRNAME/../../entrypoint.sh"
+  DOCKER_HEALTH_PROJECT_SCOPE="target-project"
+  run get_service_runtime_tag web
+  [ "$status" -eq 0 ]
+  [ "$output" = "HEALTHY" ]
+  grep -F 'label=com.docker.compose.project=target-project' "$marker"
+  ! grep -F 'label=com.docker.compose.service=web' "$marker" >/dev/null || true
+  rm -f "$marker"
+}
+
+@test "runtime lookup fails closed without resolved project" {
+  docker() { printf 'unexpected docker call\n' >&2; return 1; }
+  source "$BATS_TEST_DIRNAME/../../entrypoint.sh"
+  DOCKER_HEALTH_PROJECT_SCOPE=""
+  run get_service_runtime_tag web
+  [ "$status" -eq 0 ]
+  [ "$output" = "NO_CONTAINERS" ]
+  [[ "$output" != *"unexpected docker call"* ]]
+}

--- a/tests/unit/project_scope.bats
+++ b/tests/unit/project_scope.bats
@@ -81,3 +81,17 @@
   ! grep -F 'foreign' "$marker" >/dev/null
   rm -f "$marker"
 }
+
+@test "empty compose lookup preserves ordered exact-project fallback" {
+  fake_compose() {
+    [[ "${1:-}" == "ps" ]] && return 0
+    return 1
+  }
+  source "$BATS_TEST_DIRNAME/../../entrypoint.sh"
+  DOCKER_HEALTH_PROJECT_NAME_INPUT="input-project"
+  COMPOSE_PROJECT_NAME="ambient-project"
+
+  run resolve_project_name fake_compose
+  [ "$status" -eq 0 ]
+  [ "$output" = "input-project" ]
+}

--- a/tests/v1/compose-failed.bats
+++ b/tests/v1/compose-failed.bats
@@ -20,6 +20,7 @@ load '../helpers.bash'
   assert_output --partial "Diagnostics summary"
   assert_output --partial "docker-compose.compose_failed.yml"
   assert_output --partial "docker compose output (last 25 lines)"
-  assert_output --partial "docker compose ls (all projects)"
-  assert_output --partial "docker ps --all (global)"
+  assert_output --partial "docker compose ps --all (current project)"
+  refute_output --partial "docker compose ls (all projects)"
+  refute_output --partial "docker ps --all (global)"
 }

--- a/tests/v2/compose-failed.bats
+++ b/tests/v2/compose-failed.bats
@@ -21,8 +21,9 @@ load '../helpers.bash'
   assert_output --partial "Diagnostics summary"
   assert_output --partial "docker-compose.compose_failed.yml"
   assert_output --partial "docker compose output (last 25 lines)"
-  assert_output --partial "docker compose ls (all projects)"
-  assert_output --partial "docker ps --all (global)"
+  assert_output --partial "docker compose ps --all (current project)"
+  refute_output --partial "docker compose ls (all projects)"
+  refute_output --partial "docker ps --all (global)"
 }
 
 @test "docker-command: compose up fails but exited container is treated as unhealthy" {

--- a/tests/v2/project_name.bats
+++ b/tests/v2/project_name.bats
@@ -43,6 +43,7 @@ load '../helpers.bash'
   export INPUT_COMPOSE_PROJECT_NAME="explicitname"
   export INPUT_AUTO_APPLY_PROJECT_NAME="true"
   export COMPOSE_PROJECT_NAME="envname"
+  export HC_SKIP_PROJECT_INJECT="1"
 
   tmpdir="$(mktemp -d)"
   export INPUT_PROJECT_NAME_ENV_FILE="${tmpdir}/system.env"
@@ -60,6 +61,7 @@ load '../helpers.bash'
   export INPUT_TIMEOUT="0"
   export INPUT_AUTO_APPLY_PROJECT_NAME="true"
   export COMPOSE_PROJECT_NAME="envname"
+  export HC_SKIP_PROJECT_INJECT="1"
   unset INPUT_COMPOSE_PROJECT_NAME
 
   tmpdir="$(mktemp -d)"
@@ -78,6 +80,7 @@ load '../helpers.bash'
   export INPUT_TIMEOUT="0"
   export INPUT_AUTO_APPLY_PROJECT_NAME="true"
   export GITHUB_REPOSITORY="ylazakovich/compose-health-check-action"
+  export HC_SKIP_PROJECT_INJECT="1"
   unset INPUT_COMPOSE_PROJECT_NAME
   unset COMPOSE_PROJECT_NAME
 


### PR DESCRIPTION
## Summary

- transport composite action inputs through environment variables instead of interpolating them into shell source
- harden Compose `up` service parsing for scaled services and operand-taking options
- keep Docker diagnostics scoped to the exact Compose project and honor project selection from `docker-command`
- pin third-party workflow actions to immutable commit SHAs

## Regression coverage

- literal command substitutions, backticks, quotes, newlines, and shell metacharacters remain data
- `--scale`, `--no-attach`, profiles, project-name forms, and `--` parsing
- conflicting project names cannot include same-named containers from another Compose project

## Verification

- `bash -n`
- actionlint
- `git diff --check`
- exact-archive parser, action-transport, project-scope, and fake-Docker probes
- independent exact-head review: PASS on `2c0969980990522b4baf6815e2c365e608ce0eab`

Full Bats/Docker and configured lint gates run in GitHub Actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Docker Compose project detection and container filtering for more accurate health checks and diagnostics.
  - Compose failure messages now display only containers from the relevant project.
  - Improved handling of service names, scaled services, command-line options, and arguments after `--`.
  - Improved handling of special characters and multiline input values.

- **Security & Reliability**
  - Automated workflows now use immutable action revisions and safer credential handling.

- **Tests**
  - Expanded coverage for project scoping, service parsing, input handling, and failure diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->