### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## v2.3.0.SNAPSHOT
+## v2.4.0.SNAPSHOT
+
+## v2.3.0 (31.07.2026)
+
+- Hardened composite-action input transport so shell metacharacters cannot be evaluated as generated shell source.
+- Corrected Compose service parsing for scaled services and operand-taking options, including `--no-attach` and `-t`/`--timeout`.
+- Made explicit `-p`/`--project-name` selection authoritative with Docker Compose last-value-wins semantics and safe ordered fallbacks when no containers exist yet.
+- Scoped container discovery and diagnostics to the resolved Compose project and fail closed when the project cannot be resolved.
+- Pinned internal workflow actions to immutable commits and disabled persisted checkout credentials.
 
 ## v2.2.0 (27.01.2026)
 


### PR DESCRIPTION
## Summary

Prepare the immutable `v2.3.0` release after the guarded merge of #72.

- finalize the `v2.3.0` changelog section
- advance the development marker to `v2.4.0.SNAPSHOT`
- document input-transport hardening, Compose parsing/project scoping, and workflow hardening

## Verification

- [x] Change is limited to `CHANGELOG.md`
- [x] `git diff --check`
- [x] Release version follows the existing `v2.3.0.SNAPSHOT` marker

After this PR is reviewed and merged, `v2.3.0` will be tagged at the exact merge commit and published as a non-draft, non-prerelease GitHub release.
