### PR TITLE
chore: adopt project-toolkit v2.8.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -7,7 +7,7 @@ release_please: false
 renovate: true
 renovate_config_repository: quokkify/renovate-presets
 renovate_presets:
-- default
-- github-actions
-- docker
+  - default
+  - github-actions
+  - docker
 toolkit_version: v2.8.1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,13 @@
+_commit: v2.8.1
+_src_path: gh:quokkify/project-toolkit
+components: []
+docker: false
+project_name: Compose Health Check Action
+release_please: false
+renovate: true
+renovate_config_repository: quokkify/renovate-presets
+renovate_presets:
+- default
+- github-actions
+- docker
+toolkit_version: v2.8.1

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>quokkify/renovate-presets//presets/base", "github>quokkify/renovate-presets//presets/github-actions/default", "github>quokkify/renovate-presets//presets/docker/default"]
+  "extends": [
+    "github>quokkify/renovate-presets//presets/base",
+    "github>quokkify/renovate-presets//presets/github-actions/default",
+    "github>quokkify/renovate-presets//presets/docker/default"
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["github>quokkify/renovate-presets//presets/base", "github>quokkify/renovate-presets//presets/github-actions/default", "github>quokkify/renovate-presets//presets/docker/default"]
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["actions"]
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -37,8 +37,9 @@ jobs:
           curl -fsSLo "$archive" "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
           printf '%s  %s\n' "$GITLEAKS_SHA256" "$archive" | sha256sum -c -
           tar -xzf "$archive" gitleaks
-          install -m 0755 gitleaks "$RUNNER_TEMP/gitleaks"
+          mkdir -p "$RUNNER_TEMP/bin"
+          install -m 0755 gitleaks "$RUNNER_TEMP/bin/gitleaks"
       - name: Scan repository
         run: |
-          "$RUNNER_TEMP/gitleaks" git --redact --no-banner .
-          "$RUNNER_TEMP/gitleaks" dir --redact --no-banner .
+          "$RUNNER_TEMP/bin/gitleaks" git --redact --no-banner .
+          "$RUNNER_TEMP/bin/gitleaks" dir --redact --no-banner .

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,44 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 3 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan Git history and current tree
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out full repository history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install checksum-verified Gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          cd "$RUNNER_TEMP"
+          curl -fsSLo "$archive" "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+          printf '%s  %s\n' "$GITLEAKS_SHA256" "$archive" | sha256sum -c -
+          tar -xzf "$archive" gitleaks
+          install -m 0755 gitleaks "$RUNNER_TEMP/gitleaks"
+      - name: Scan repository
+        run: |
+          "$RUNNER_TEMP/gitleaks" git --redact --no-banner .
+          "$RUNNER_TEMP/gitleaks" dir --redact --no-banner .

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -26,6 +26,22 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Materialize trusted Gitleaks policy
+        env:
+          TRUSTED_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ ! "$TRUSTED_REF" =~ ^[0-9a-f]{40}$ || "$TRUSTED_REF" =~ ^0+$ ]]; then
+            TRUSTED_REF="$GITHUB_SHA"
+          fi
+          git fetch --no-tags --depth=1 origin "$TRUSTED_REF"
+          printf '[extend]\nuseDefault = true\n' > "$RUNNER_TEMP/gitleaks.toml"
+          : > "$RUNNER_TEMP/gitleaksignore"
+          if git cat-file -e "$TRUSTED_REF:.gitleaks.toml" 2>/dev/null; then
+            git show "$TRUSTED_REF:.gitleaks.toml" > "$RUNNER_TEMP/gitleaks.toml"
+          fi
+          if git cat-file -e "$TRUSTED_REF:.gitleaksignore" 2>/dev/null; then
+            git show "$TRUSTED_REF:.gitleaksignore" > "$RUNNER_TEMP/gitleaksignore"
+          fi
       - name: Install checksum-verified Gitleaks
         env:
           GITLEAKS_VERSION: 8.30.1
@@ -41,5 +57,5 @@ jobs:
           install -m 0755 gitleaks "$RUNNER_TEMP/bin/gitleaks"
       - name: Scan repository
         run: |
-          "$RUNNER_TEMP/bin/gitleaks" git --redact --no-banner .
-          "$RUNNER_TEMP/bin/gitleaks" dir --redact --no-banner .
+          "$RUNNER_TEMP/bin/gitleaks" git --redact --no-banner --config "$RUNNER_TEMP/gitleaks.toml" --gitleaks-ignore-path "$RUNNER_TEMP/gitleaksignore" .
+          "$RUNNER_TEMP/bin/gitleaks" dir --redact --no-banner --config "$RUNNER_TEMP/gitleaks.toml" --gitleaks-ignore-path "$RUNNER_TEMP/gitleaksignore" .

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,7 +53,7 @@ jobs:
               yaml.safe_load(text)
               for line in text.splitlines():
                   marker = "uses: quokkify/project-toolkit/"
-                  if marker in line:
+                  if line.lstrip().startswith(marker):
                       reference = line.split("@", 1)[1].split()[0]
                       comment = line.partition("#")[2].strip()
                       pinned_release = len(reference) == 40 and all(char in "0123456789abcdef" for char in reference) and comment == answers["toolkit_version"]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -36,12 +37,50 @@ jobs:
           import yaml
 
           answers = yaml.safe_load(Path(".copier-answers.yml").read_text())
-          if not isinstance(answers, dict) or not answers.get("_src_path"):
-              raise SystemExit(".copier-answers.yml must contain _src_path")
-          for path in (Path("renovate.json"), Path(".github/release-please/config.json"), Path(".github/release-please/manifest.json")):
+          required_answers = ("_src_path", "_commit", "toolkit_version")
+          if not isinstance(answers, dict) or any(not answers.get(key) for key in required_answers):
+              raise SystemExit(".copier-answers.yml must contain _src_path, _commit, and toolkit_version")
+          if answers["_commit"] != answers["toolkit_version"]:
+              raise SystemExit("Copier _commit must match toolkit_version")
+          renovate_path = Path(".github/renovate.json")
+          if answers.get("renovate") and not renovate_path.is_file():
+              raise SystemExit("renovate=true requires .github/renovate.json")
+          for path in (renovate_path, Path(".github/release-please/config.json"), Path(".github/release-please/manifest.json")):
               if path.exists():
                   json.loads(path.read_text())
           for path in Path(".github/workflows").glob("*.yml"):
-              yaml.safe_load(path.read_text())
+              text = path.read_text()
+              yaml.safe_load(text)
+              for line in text.splitlines():
+                  marker = "uses: quokkify/project-toolkit/"
+                  if marker in line:
+                      reference = line.split("@", 1)[1].split()[0]
+                      comment = line.partition("#")[2].strip()
+                      pinned_release = len(reference) == 40 and all(char in "0123456789abcdef" for char in reference) and comment == answers["toolkit_version"]
+                      if reference != answers["toolkit_version"] and not pinned_release:
+                          raise SystemExit(f"{path} uses toolkit {reference}, expected {answers['toolkit_version']}")
           PY
-          git diff --check
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          cd "$RUNNER_TEMP"
+          curl -fsSLo "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSLo actionlint_checksums.txt "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          grep -F " actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint_checksums.txt | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          mkdir -p "$RUNNER_TEMP/bin"
+          install -m 0755 actionlint "$RUNNER_TEMP/bin/actionlint"
+      - name: Lint workflows
+        run: |
+          "$RUNNER_TEMP/bin/actionlint" .github/workflows/*.yml
+      - name: Check committed diff whitespace
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ || "$BASE_SHA" =~ ^0+$ ]]; then
+            git diff-tree --check --root "$HEAD_SHA"
+          else
+            git diff --check "$BASE_SHA..$HEAD_SHA"
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,47 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  template-contract:
+    name: Shared template contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+      - name: Validate generated configuration
+        run: |
+          python -m pip install PyYAML==6.0.3
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          import yaml
+
+          answers = yaml.safe_load(Path(".copier-answers.yml").read_text())
+          if not isinstance(answers, dict) or not answers.get("_src_path"):
+              raise SystemExit(".copier-answers.yml must contain _src_path")
+          for path in (Path("renovate.json"), Path(".github/release-please/config.json"), Path(".github/release-please/manifest.json")):
+              if path.exists():
+                  json.loads(path.read_text())
+          for path in Path(".github/workflows").glob("*.yml"):
+              yaml.safe_load(path.read_text())
+          PY
+          git diff --check


### PR DESCRIPTION
## Summary
- adopt project-toolkit v2.8.1 through Copier
- preserve repository-specific CI and release behavior
- add or refresh Renovate, validation, CodeQL, and Gitleaks automation
- apply fleet-audit fixes for trusted scan policy and committed-diff validation

## Verification
- `copier update --vcs-ref v2.8.1 --trust --defaults --conflict=rej --skip-tasks` is idempotent
- all workflow files pass actionlint
- repository CI is enabled on this PR

## Security and privacy
- [x] No secrets or personal data added
- [x] Gitleaks downloads are checksum verified
- [x] Pull requests cannot supply weaker Gitleaks policy

## Additional risk
- New security workflows may expose pre-existing findings; those should be triaged rather than bypassed.