### PR TITLE
fix: use Renovate-compatible Copier source URL

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 _commit: v2.8.1
-_src_path: gh:quokkify/project-toolkit
+_src_path: https://github.com/quokkify/project-toolkit.git
 components: []
 docker: false
 project_name: Compose Health Check Action


### PR DESCRIPTION
## Summary
- replace Copier’s GitHub shorthand in `_src_path` with the equivalent HTTPS Git URL
- preserve the exact template version (`v2.8.1`) and every project answer

## Root cause
Renovate’s built-in Copier manager detects `.copier-answers.yml` by design and looks up `_src_path` through the `git-tags` datasource. Copier accepts `gh:owner/repo`, but Renovate does not expand that shorthand, so Git receives a non-Git URL and reports `no-result`.

## Verification
- answers YAML parses successfully
- `git ls-remote --tags https://github.com/quokkify/project-toolkit.git refs/tags/v2.8.1` resolves the tag
- Copier copy smoke test with the HTTPS URL preserves `_src_path` and `_commit`
- `git diff --check`

## Security and privacy
- no dependency versions, generated files, credentials, or project-specific answers changed

## Additional risks
- none expected; both URLs identify the same public Git repository, but the HTTPS form is understood by Copier, Git, and Renovate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project source reference to use its full HTTPS repository URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->