### PR TITLE
fix(ci): align Copier template baseline

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: v2.8.1
+_commit: v2.8.2
 _src_path: https://github.com/quokkify/project-toolkit.git
 components: []
 docker: false
@@ -10,4 +10,4 @@ renovate_presets:
   - default
   - github-actions
   - docker
-toolkit_version: v2.8.1
+toolkit_version: v2.8.2


### PR DESCRIPTION
1|## Summary
2|
3|- align Copier `_commit` and `toolkit_version` with the `v2.8.2` template content already present in this repository
4|- update pinned `project-toolkit` workflow/action references to the immutable `v2.8.2` commit where applicable
5|- preserve repository-specific README, CI, and release workflow behavior
6|
7|## Root cause
8|
9|The repository had already received files generated from `project-toolkit` `v2.8.2`, but `.copier-answers.yml` still declared `v2.8.1`. Copier therefore used the wrong old-template baseline for its three-way merge and produced `.rej` conflicts during the fleet audit.
10|
11|## Verification
12|
13|- `copier update --trust --defaults --conflict=rej --skip-tasks --vcs-ref v2.8.2 .`
14|- verified the update exits successfully, creates no `.rej` files, and leaves the committed tree clean when run through the corrected fleet updater
15|- `git diff --check`
16|- reusable workflow/action references remain pinned to commit `403467a8e9e5518dfa641c538c857af789a7a84e` with `# v2.8.2`
17|