### PR TITLE
chore(template): update shared project template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -8,7 +8,7 @@ release_please: false
 renovate: true
 renovate_config_repository: quokkify/renovate-presets
 renovate_presets:
-- default
-- github-actions
-- docker
-toolkit_version: v2.8.2
+  - default
+  - github-actions
+  - docker
+toolkit_version: v2.10.1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,6 @@
-_commit: v2.8.2
+_commit: v2.10.1
 _src_path: https://github.com/quokkify/project-toolkit.git
+allure_report: false
 components: []
 docker: false
 project_name: Compose Health Check Action
@@ -7,7 +8,7 @@ release_please: false
 renovate: true
 renovate_config_repository: quokkify/renovate-presets
 renovate_presets:
-  - default
-  - github-actions
-  - docker
+- default
+- github-actions
+- docker
 toolkit_version: v2.8.2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,6 +45,15 @@ jobs:
           renovate_path = Path(".github/renovate.json")
           if answers.get("renovate") and not renovate_path.is_file():
               raise SystemExit("renovate=true requires .github/renovate.json")
+          allure_paths = (
+              Path(".github/workflows/allure-report.yml"),
+              Path(".github/allure/allurerc.mjs"),
+              Path(".github/allure/safe_extract.py"),
+          )
+          if answers.get("allure_report") and any(not path.is_file() for path in allure_paths):
+              raise SystemExit("allure_report=true requires its generated workflow, config, and bounded extractor")
+          if answers.get("allure_publish_pages") and not answers.get("allure_report"):
+              raise SystemExit("allure_publish_pages=true requires allure_report=true")
           for path in (renovate_path, Path(".github/release-please/config.json"), Path(".github/release-please/manifest.json")):
               if path.exists():
                   json.loads(path.read_text())


### PR DESCRIPTION
## Summary

Automated `copier update` from the shared [`quokkify/project-toolkit`](https://github.com/quokkify/project-toolkit) template.

This keeps the organization baseline (validation, CodeQL, Gitleaks, Release Please, and Renovate) synchronized while leaving merge approval to maintainers.

## Generated changes

- `.copier-answers.yml`
- `.github/workflows/validate.yml`

## Verification

- `copier update --trust --defaults --conflict=rej --skip-tasks`
- `git diff --cached --check`

Do not edit the automation branch directly; make project-specific changes after merging or adjust the Copier answers/template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Allure reporting in generated projects.
  - Added an option to publish Allure reports to Pages when reporting is enabled.
  - Updated the project template baseline to a newer version.

- **Bug Fixes**
  - Improved validation to ensure Allure reporting settings generate the required reporting components.
  - Added checks preventing report publishing from being enabled without Allure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->