### PR TITLE
feat: support project lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Example:
     project-name-env-file: system.env
 ```
 
-Both lifecycle hooks are resolved inside `GITHUB_WORKSPACE` and receive the normalized Compose profiles as positional arguments. The before hook is sourced in the same shell that starts Compose, so exported values are available to Compose interpolation. A failing hook fails the action; arbitrary command strings are not evaluated.
+Both lifecycle hooks are resolved and validated inside `GITHUB_WORKSPACE` before Compose starts, so a missing file or workspace-escaping symlink cannot leave a newly started stack behind. Hooks receive the normalized Compose profiles as positional arguments. The before hook is sourced in the same errexit-enabled lifecycle shell that starts Compose, so exported values are available to Compose interpolation and an unhandled command failure stops the lifecycle. A failing hook fails the action; arbitrary command strings are not evaluated.
 
 ```bash
 # tools/environment/prepare-ci.sh

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ✅ Runs Docker Compose  
 ✅ Autodetection host platform  
 ✅ Waits for container healthchecks  
+✅ Runs optional project-owned bootstrap and readiness hooks
 ✅ Fails on unhealthy or broken services  
 ✅ Shows clear diagnostics on error
 
@@ -64,6 +65,8 @@ pass or fail CI
 | `compose-files`           | no       | One or more docker-compose files (default: `docker-compose.yml`, used when `docker-command` is empty) |
 | `compose-project-name`    | no       | Explicit docker compose project name (overridden by `-p/--project-name` in `docker-command`)          |
 | `compose-profiles`        | no       | One or more compose profiles (space or newline separated; ignored when `docker-command` is set)       |
+| `before-compose-hook`     | no       | Repository-relative Bash file sourced before Compose; may export interpolation variables              |
+| `after-health-hook`       | no       | Repository-relative Bash file sourced after container checks for project-specific readiness           |
 | `compose-services`        | no       | Services to check (defaults to all services when omitted; ignored when `docker-command` is set)       |
 | `additional-compose-args` | no       | Additional args for docker compose (e.g. `--quiet-pull` or `--build`)                                 |
 | `services`                | no       | Deprecated alias for `compose-services`                                                               |
@@ -87,10 +90,22 @@ Example:
       api
     compose-profiles: |
       default
+    before-compose-hook: tools/environment/prepare-ci.sh
+    after-health-hook: tools/environment/check-readiness.sh
     timeout: 60
     log-lines: 50
     auto-apply-project-name: true
     project-name-env-file: system.env
+```
+
+Both lifecycle hooks are resolved inside `GITHUB_WORKSPACE` and receive the normalized Compose profiles as positional arguments. The before hook is sourced in the same shell that starts Compose, so exported values are available to Compose interpolation. A failing hook fails the action; arbitrary command strings are not evaluated.
+
+```bash
+# tools/environment/prepare-ci.sh
+export API_PORT="$(python3 tools/find_free_port.py)"
+
+# tools/environment/check-readiness.sh
+curl --fail --retry 20 --retry-delay 2 http://127.0.0.1:"$API_PORT"/ready
 ```
 
 Run a custom compose command (replaces `compose-files` and `additional-compose-args`):

--- a/action.yml
+++ b/action.yml
@@ -150,27 +150,30 @@ runs:
           resolved_hook="$(bash "${SCRIPT_DIR}/lib/resolve-lifecycle-hook.sh" "$hook_input" "${GITHUB_WORKSPACE:-}" "$hook_name")"
 
           local -a hook_profiles=()
-          if [[ -n "$compose_profiles_input" ]]; then
+          if [[ -z "$docker_command_input" && -n "$compose_profiles_input" ]]; then
             read -r -a hook_profiles <<<"$(tr '\n' ' ' <<<"$compose_profiles_input")"
           fi
 
           echo "Running $hook_name: $hook_input"
           # Hooks are repository-owned code. Source them so before-compose exports
           # remain available to Docker Compose interpolation in this lifecycle.
-          source "$resolved_hook" "${hook_profiles[@]}"
+          # Reset positional parameters first: `source file` with no explicit
+          # arguments would otherwise leak run_hook's own name/path arguments.
+          set -- "${hook_profiles[@]}"
+          source "$resolved_hook" "$@"
         }
 
         run_lifecycle() {
-          set -e
-          run_hook "before-compose-hook" "$before_compose_hook_input"
-          bash "${SCRIPT_DIR}/entrypoint.sh" "${CMD[@]}"
-          run_hook "after-health-hook" "$after_health_hook_input"
+          run_hook "before-compose-hook" "$before_compose_hook_input" || return $?
+          bash "${SCRIPT_DIR}/entrypoint.sh" "${CMD[@]}" || return $?
+          run_hook "after-health-hook" "$after_health_hook_input" || return $?
         }
 
         set +e
         run_lifecycle 2>&1 | tee "$TMP_OUT"
-        rc=${PIPESTATUS[0]}
+        lifecycle_status=("${PIPESTATUS[@]}")
         set -e
+        rc="${lifecycle_status[0]}"
 
         OUTPUT_B64="$(base64 <"$TMP_OUT" | tr -d '\n')"
         echo "summary_b64=$OUTPUT_B64" >>"$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -134,43 +134,24 @@ runs:
           bash "${SCRIPT_DIR}/lib/build-compose-command.sh"
         )
 
+        resolved_before_hook="$(bash "${SCRIPT_DIR}/lib/resolve-lifecycle-hook.sh" "$before_compose_hook_input" "${GITHUB_WORKSPACE:-}" "before-compose-hook")"
+        resolved_after_hook="$(bash "${SCRIPT_DIR}/lib/resolve-lifecycle-hook.sh" "$after_health_hook_input" "${GITHUB_WORKSPACE:-}" "after-health-hook")"
+
         TMP_OUT="$(mktemp)"
         JSON_TMP="$(mktemp)"
 
         # Tell the healthcheck script where to write JSON (if report-format is json/both).
         export DOCKER_HEALTH_REPORT_JSON_FILE="$JSON_TMP"
         export DOCKER_HEALTH_REPORT_FORMAT="$report_format_input"
+        export SCRIPT_DIR docker_command_input compose_profiles_input
+        export before_compose_hook_input after_health_hook_input
+        export resolved_before_hook resolved_after_hook
 
-        run_hook() {
-          local hook_name="$1"
-          local hook_input="$2"
-          [[ -n "$hook_input" ]] || return 0
-
-          local resolved_hook
-          resolved_hook="$(bash "${SCRIPT_DIR}/lib/resolve-lifecycle-hook.sh" "$hook_input" "${GITHUB_WORKSPACE:-}" "$hook_name")"
-
-          local -a hook_profiles=()
-          if [[ -z "$docker_command_input" && -n "$compose_profiles_input" ]]; then
-            read -r -a hook_profiles <<<"$(tr '\n' ' ' <<<"$compose_profiles_input")"
-          fi
-
-          echo "Running $hook_name: $hook_input"
-          # Hooks are repository-owned code. Source them so before-compose exports
-          # remain available to Docker Compose interpolation in this lifecycle.
-          # Reset positional parameters first: `source file` with no explicit
-          # arguments would otherwise leak run_hook's own name/path arguments.
-          set -- "${hook_profiles[@]}"
-          source "$resolved_hook" "$@"
-        }
-
-        run_lifecycle() {
-          run_hook "before-compose-hook" "$before_compose_hook_input" || return $?
-          bash "${SCRIPT_DIR}/entrypoint.sh" "${CMD[@]}" || return $?
-          run_hook "after-health-hook" "$after_health_hook_input" || return $?
-        }
-
+        # Execute the complete lifecycle in a fresh errexit-enabled shell. The parent
+        # disables errexit only to capture the pipeline status; that must not weaken
+        # `set -e` inside sourced project hooks.
         set +e
-        run_lifecycle 2>&1 | tee "$TMP_OUT"
+        bash "${SCRIPT_DIR}/lib/run-lifecycle.sh" "${CMD[@]}" 2>&1 | tee "$TMP_OUT"
         lifecycle_status=("${PIPESTATUS[@]}")
         set -e
         rc="${lifecycle_status[0]}"

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,14 @@ inputs:
     description: "One or more compose profiles (space or newline separated). Ignored when docker-command is set."
     required: false
     default: ""
+  before-compose-hook:
+    description: "Optional repository-relative Bash file sourced before docker compose; receives compose profiles as arguments and may export Compose interpolation variables."
+    required: false
+    default: ""
+  after-health-hook:
+    description: "Optional repository-relative Bash file sourced after built-in container health checks; receives compose profiles as arguments and may perform project-specific readiness checks."
+    required: false
+    default: ""
   docker-command:
     description: "Full docker compose command to execute instead of compose-files/services (e.g. docker compose -f docker-compose.yml up -d web)"
     required: false
@@ -86,6 +94,8 @@ runs:
         REPORT_FORMAT_INPUT: ${{ inputs.report-format }}
         DOCKER_COMMAND_INPUT: ${{ inputs.docker-command }}
         COMPOSE_PROFILES_INPUT: ${{ inputs.compose-profiles }}
+        BEFORE_COMPOSE_HOOK_INPUT: ${{ inputs.before-compose-hook }}
+        AFTER_HEALTH_HOOK_INPUT: ${{ inputs.after-health-hook }}
       run: |
         set -euo pipefail
 
@@ -98,6 +108,8 @@ runs:
         report_format_input="${REPORT_FORMAT_INPUT}"
         docker_command_input="${DOCKER_COMMAND_INPUT}"
         compose_profiles_input="${COMPOSE_PROFILES_INPUT}"
+        before_compose_hook_input="${BEFORE_COMPOSE_HOOK_INPUT}"
+        after_health_hook_input="${AFTER_HEALTH_HOOK_INPUT}"
 
         services_to_use="$compose_services_input"
         if [[ -z "$services_to_use" ]]; then
@@ -129,16 +141,42 @@ runs:
         export DOCKER_HEALTH_REPORT_JSON_FILE="$JSON_TMP"
         export DOCKER_HEALTH_REPORT_FORMAT="$report_format_input"
 
+        run_hook() {
+          local hook_name="$1"
+          local hook_input="$2"
+          [[ -n "$hook_input" ]] || return 0
+
+          local resolved_hook
+          resolved_hook="$(bash "${SCRIPT_DIR}/lib/resolve-lifecycle-hook.sh" "$hook_input" "${GITHUB_WORKSPACE:-}" "$hook_name")"
+
+          local -a hook_profiles=()
+          if [[ -n "$compose_profiles_input" ]]; then
+            read -r -a hook_profiles <<<"$(tr '\n' ' ' <<<"$compose_profiles_input")"
+          fi
+
+          echo "Running $hook_name: $hook_input"
+          # Hooks are repository-owned code. Source them so before-compose exports
+          # remain available to Docker Compose interpolation in this lifecycle.
+          source "$resolved_hook" "${hook_profiles[@]}"
+        }
+
+        run_lifecycle() {
+          set -e
+          run_hook "before-compose-hook" "$before_compose_hook_input"
+          bash "${SCRIPT_DIR}/entrypoint.sh" "${CMD[@]}"
+          run_hook "after-health-hook" "$after_health_hook_input"
+        }
+
         set +e
-        bash "${SCRIPT_DIR}/entrypoint.sh" "${CMD[@]}" 2>&1 | tee "$TMP_OUT"
+        run_lifecycle 2>&1 | tee "$TMP_OUT"
         rc=${PIPESTATUS[0]}
         set -e
 
         OUTPUT_B64="$(base64 <"$TMP_OUT" | tr -d '\n')"
         echo "summary_b64=$OUTPUT_B64" >>"$GITHUB_OUTPUT"
 
-        # JSON output is optional; only publish if present and non-empty
-        if [[ -s "$JSON_TMP" ]]; then
+        # JSON describes the complete lifecycle only when Compose and both hooks pass.
+        if [[ "$rc" -eq 0 && -s "$JSON_TMP" ]]; then
           JSON_B64="$(base64 <"$JSON_TMP" | tr -d '\n')"
           echo "report_json_b64=$JSON_B64" >>"$GITHUB_OUTPUT"
         else

--- a/lib/resolve-lifecycle-hook.sh
+++ b/lib/resolve-lifecycle-hook.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_path="${1:-}"
+workspace="${2:-${GITHUB_WORKSPACE:-}}"
+hook_name="${3:-lifecycle hook}"
+
+if [[ -z "$hook_path" ]]; then
+  exit 0
+fi
+
+if [[ -z "$workspace" ]]; then
+  echo "GITHUB_WORKSPACE is required when $hook_name is configured." >&2
+  exit 1
+fi
+
+python3 - "$workspace" "$hook_path" "$hook_name" <<'PY'
+from pathlib import Path
+import sys
+
+workspace_raw, hook_raw, hook_name = sys.argv[1:]
+
+if any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in hook_raw):
+    raise SystemExit(f"{hook_name} must be a repository-relative path without whitespace or control characters")
+
+hook = Path(hook_raw)
+if not hook_raw or hook.is_absolute() or hook_raw.startswith("~") or ":" in hook_raw:
+    raise SystemExit(f"{hook_name} must be a repository-relative path")
+if any(part in {"", ".", ".."} for part in hook.parts):
+    raise SystemExit(f"{hook_name} must not contain empty, dot, or traversal components")
+
+workspace = Path(workspace_raw).resolve(strict=True)
+candidate = (workspace / hook).resolve(strict=True)
+try:
+    candidate.relative_to(workspace)
+except ValueError as error:
+    raise SystemExit(f"{hook_name} must resolve inside GITHUB_WORKSPACE") from error
+if not candidate.is_file():
+    raise SystemExit(f"{hook_name} must resolve to a regular file")
+
+print(candidate)
+PY

--- a/lib/run-lifecycle.sh
+++ b/lib/run-lifecycle.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SCRIPT_DIR:?SCRIPT_DIR is required}"
+
+before_compose_hook_input="${before_compose_hook_input:-}"
+after_health_hook_input="${after_health_hook_input:-}"
+resolved_before_hook="${resolved_before_hook:-}"
+resolved_after_hook="${resolved_after_hook:-}"
+docker_command_input="${docker_command_input:-}"
+compose_profiles_input="${compose_profiles_input:-}"
+
+hook_profiles=()
+if [[ -z "$docker_command_input" && -n "$compose_profiles_input" ]]; then
+  read -r -a hook_profiles <<<"$(tr '\n' ' ' <<<"$compose_profiles_input")"
+fi
+
+run_hook() {
+  local hook_name="$1"
+  local hook_input="$2"
+  local resolved_hook="$3"
+  [[ -n "$hook_input" ]] || return 0
+
+  echo "Running $hook_name: $hook_input"
+  # Hooks are repository-owned code. Source them so before-compose exports
+  # remain available to Docker Compose interpolation in this lifecycle.
+  # Reset positional parameters first: `source file` with no explicit
+  # arguments would otherwise leak run_hook's own arguments.
+  set -- "${hook_profiles[@]}"
+  # The resolver already canonicalized this repository-owned path inside GITHUB_WORKSPACE.
+  # shellcheck disable=SC1090
+  source "$resolved_hook" "$@"
+}
+
+run_hook "before-compose-hook" "$before_compose_hook_input" "$resolved_before_hook"
+bash "${SCRIPT_DIR}/entrypoint.sh" "$@"
+run_hook "after-health-hook" "$after_health_hook_input" "$resolved_after_hook"

--- a/tests/unit/action_inputs.bats
+++ b/tests/unit/action_inputs.bats
@@ -8,10 +8,18 @@
 
 @test "all shell-consumed public inputs have stable env mappings" {
   action="$BATS_TEST_DIRNAME/../../action.yml"
-  for name in compose-files additional-compose-args services compose-services report-format docker-command compose-profiles; do
+  for name in compose-files additional-compose-args services compose-services report-format docker-command compose-profiles before-compose-hook after-health-hook; do
     env_name="$(printf '%s' "$name" | tr '[:lower:]-' '[:upper:]_')_INPUT"
     grep -F "$env_name: \${{ inputs.$name }}" "$action"
   done
+}
+
+@test "lifecycle hooks are resolved as paths and never evaluated as shell source strings" {
+  action="$BATS_TEST_DIRNAME/../../action.yml"
+  grep -F 'resolve-lifecycle-hook.sh' "$action"
+  grep -F 'source "$resolved_hook" "${hook_profiles[@]}"' "$action"
+  run grep -E '(^|[[:space:]])eval([[:space:]]|$)' "$action"
+  [ "$status" -eq 1 ]
 }
 
 @test "build command transports shell metacharacters as data" {

--- a/tests/unit/action_inputs.bats
+++ b/tests/unit/action_inputs.bats
@@ -14,15 +14,21 @@
   done
 }
 
-@test "lifecycle hooks are resolved as paths and never evaluated as shell source strings" {
+@test "lifecycle hooks are pre-resolved and delegated without eval" {
   action="$BATS_TEST_DIRNAME/../../action.yml"
-  grep -F 'resolve-lifecycle-hook.sh' "$action"
-  grep -F 'set -- "${hook_profiles[@]}"' "$action"
-  grep -F 'source "$resolved_hook" "$@"' "$action"
-  grep -F '[[ -z "$docker_command_input" && -n "$compose_profiles_input" ]]' "$action"
-  grep -F 'run_hook "before-compose-hook" "$before_compose_hook_input" || return $?' "$action"
+  runner="$BATS_TEST_DIRNAME/../../lib/run-lifecycle.sh"
+
+  before_line="$(grep -n 'resolved_before_hook="$(bash' "$action" | cut -d: -f1)"
+  after_line="$(grep -n 'resolved_after_hook="$(bash' "$action" | cut -d: -f1)"
+  runner_line="$(grep -n 'lib/run-lifecycle.sh' "$action" | cut -d: -f1)"
+  [ "$before_line" -lt "$runner_line" ]
+  [ "$after_line" -lt "$runner_line" ]
+
+  grep -F 'set -- "${hook_profiles[@]}"' "$runner"
+  grep -F 'source "$resolved_hook" "$@"' "$runner"
+  grep -F '[[ -z "$docker_command_input" && -n "$compose_profiles_input" ]]' "$runner"
   grep -F 'rc="${lifecycle_status[0]}"' "$action"
-  run grep -E '(^|[[:space:]])eval([[:space:]]|$)' "$action"
+  run grep -E '(^|[[:space:]])eval([[:space:]]|$)' "$action" "$runner"
   [ "$status" -eq 1 ]
 }
 

--- a/tests/unit/action_inputs.bats
+++ b/tests/unit/action_inputs.bats
@@ -17,7 +17,11 @@
 @test "lifecycle hooks are resolved as paths and never evaluated as shell source strings" {
   action="$BATS_TEST_DIRNAME/../../action.yml"
   grep -F 'resolve-lifecycle-hook.sh' "$action"
-  grep -F 'source "$resolved_hook" "${hook_profiles[@]}"' "$action"
+  grep -F 'set -- "${hook_profiles[@]}"' "$action"
+  grep -F 'source "$resolved_hook" "$@"' "$action"
+  grep -F '[[ -z "$docker_command_input" && -n "$compose_profiles_input" ]]' "$action"
+  grep -F 'run_hook "before-compose-hook" "$before_compose_hook_input" || return $?' "$action"
+  grep -F 'rc="${lifecycle_status[0]}"' "$action"
   run grep -E '(^|[[:space:]])eval([[:space:]]|$)' "$action"
   [ "$status" -eq 1 ]
 }

--- a/tests/unit/lifecycle_hooks.bats
+++ b/tests/unit/lifecycle_hooks.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+setup() {
+  workspace="$(mktemp -d)"
+  mkdir -p "$workspace/hooks"
+  printf '#!/usr/bin/env bash\n' >"$workspace/hooks/readiness.sh"
+  resolver="$BATS_TEST_DIRNAME/../../lib/resolve-lifecycle-hook.sh"
+}
+
+teardown() {
+  rm -rf "$workspace"
+}
+
+@test "resolves a regular repository-relative lifecycle hook" {
+  run bash "$resolver" "hooks/readiness.sh" "$workspace" "after-health-hook"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$workspace/hooks/readiness.sh" ]
+}
+
+@test "rejects traversal absolute whitespace and missing lifecycle hooks" {
+  for path in "../outside.sh" "/tmp/outside.sh" "hooks/readiness script.sh" "hooks/missing.sh"; do
+    run bash "$resolver" "$path" "$workspace" "before-compose-hook"
+    [ "$status" -ne 0 ]
+  done
+}
+
+@test "rejects a hook symlink that resolves outside the workspace" {
+  outside="$(mktemp)"
+  ln -s "$outside" "$workspace/hooks/outside.sh"
+
+  run bash "$resolver" "hooks/outside.sh" "$workspace" "after-health-hook"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"inside GITHUB_WORKSPACE"* ]]
+
+  rm -f "$outside"
+}

--- a/tests/unit/lifecycle_runner.bats
+++ b/tests/unit/lifecycle_runner.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  ACTION_ROOT="$TEST_ROOT/action"
+  mkdir -p "$ACTION_ROOT"
+  cp "$BATS_TEST_DIRNAME/../../entrypoint.sh" "$ACTION_ROOT/entrypoint.original.sh"
+  cat >"$ACTION_ROOT/entrypoint.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'entrypoint:%s:%s\n' "${BOOTSTRAP_TOKEN:-missing}" "$*"
+SCRIPT
+  chmod +x "$ACTION_ROOT/entrypoint.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "errexit failure in before hook prevents Compose lifecycle" {
+  cat >"$TEST_ROOT/before.sh" <<'SCRIPT'
+set -e
+false
+echo should-not-run
+SCRIPT
+
+  run env \
+    SCRIPT_DIR="$ACTION_ROOT" \
+    before_compose_hook_input="hooks/before.sh" \
+    resolved_before_hook="$TEST_ROOT/before.sh" \
+    compose_profiles_input="storage redis" \
+    bash "$BATS_TEST_DIRNAME/../../lib/run-lifecycle.sh" docker compose up -d
+
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"should-not-run"* ]]
+  [[ "$output" != *"entrypoint:"* ]]
+}
+
+@test "before exports and profile arguments reach entrypoint and after hook" {
+  cat >"$TEST_ROOT/before.sh" <<'SCRIPT'
+printf 'before:%s\n' "$*"
+export BOOTSTRAP_TOKEN=ready
+SCRIPT
+  cat >"$TEST_ROOT/after.sh" <<'SCRIPT'
+printf 'after:%s\n' "$*"
+SCRIPT
+
+  run env \
+    SCRIPT_DIR="$ACTION_ROOT" \
+    before_compose_hook_input="hooks/before.sh" \
+    after_health_hook_input="hooks/after.sh" \
+    resolved_before_hook="$TEST_ROOT/before.sh" \
+    resolved_after_hook="$TEST_ROOT/after.sh" \
+    compose_profiles_input="storage redis" \
+    bash "$BATS_TEST_DIRNAME/../../lib/run-lifecycle.sh" docker compose up -d
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"before:storage redis"* ]]
+  [[ "$output" == *"entrypoint:ready:docker compose up -d"* ]]
+  [[ "$output" == *"after:storage redis"* ]]
+}
+
+@test "docker-command mode does not pass ignored profiles to hooks" {
+  cat >"$TEST_ROOT/before.sh" <<'SCRIPT'
+printf 'hook-argc:%s\n' "$#"
+SCRIPT
+
+  run env \
+    SCRIPT_DIR="$ACTION_ROOT" \
+    before_compose_hook_input="hooks/before.sh" \
+    resolved_before_hook="$TEST_ROOT/before.sh" \
+    compose_profiles_input="storage redis" \
+    docker_command_input="docker compose up -d" \
+    bash "$BATS_TEST_DIRNAME/../../lib/run-lifecycle.sh" docker compose up -d
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hook-argc:0"* ]]
+}


### PR DESCRIPTION
## Summary

- add repository-relative `before-compose-hook` sourced before Compose startup
- add repository-relative `after-health-hook` for project-specific readiness checks
- keep hook paths inside `GITHUB_WORKSPACE`, pass Compose profiles as arguments, and never evaluate command strings
- suppress the JSON success report when either hook fails

This is the first PR in the delivery chain: compose-health-check-action → project-toolkit → q4j.

## Verification

- YAML parse and Bash syntax checks
- ShellCheck for the new resolver
- path traversal, missing-file, whitespace, and external-symlink rejection probes
- extracted composite-action regression smoke: before-hook rc=6 stopped startup; after-hook rc=7 was preserved; `docker-command` passed no ignored profile arguments; failing hooks suppressed JSON
- all actionable review findings resolved on exact head `cd3d568`
- full GitHub Actions Bats matrix, formatting, shared-template validation, Gitleaks, and CodeQL passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional hooks that run before Docker Compose starts and after health checks complete.
  * Hooks receive configured Compose profiles and support workspace-relative paths.
  * Lifecycle results are published only when Compose and both hooks complete successfully.
  * Added documentation and examples for configuring and using lifecycle hooks.

* **Bug Fixes**
  * Added validation to reject unsafe, invalid, missing, or out-of-workspace hook paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->