### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## v2.4.0.SNAPSHOT
+## v2.5.0.SNAPSHOT
+
+## v2.4.0 (09.08.2026)
+
+- Added optional repository-owned `before-compose-hook` and `after-health-hook` lifecycle scripts around Compose startup and built-in health checks.
+- Resolved and validated both hook paths inside `GITHUB_WORKSPACE` before startup, rejecting absolute paths, traversal, missing files, and workspace-escaping symlinks.
+- Ran hooks in a strict lifecycle shell so before-hook exports reach Compose interpolation and unhandled hook failures stop the lifecycle with the original exit status.
+- Passed normalized Compose profiles to hooks while preserving `docker-command` profile-precedence semantics.
+- Suppressed successful JSON lifecycle output when bootstrap, Compose health, or project readiness fails, with execution-level Bats regression coverage.
 
 ## v2.3.0 (31.07.2026)
 


### PR DESCRIPTION
## Summary

Prepare the immutable `v2.4.0` release after the guarded merge of #79.

- finalize the `v2.4.0` changelog section
- advance the development marker to `v2.5.0.SNAPSHOT`
- document safe project-owned bootstrap/readiness hooks and strict failure propagation

## Verification

- [x] Change is limited to `CHANGELOG.md`
- [x] `git diff --check`
- [x] Release version follows the existing `v2.4.0.SNAPSHOT` marker

After this PR is merged, `v2.4.0` will be tagged at the exact squash commit, the moving `v2` tag will be advanced, and a non-draft, non-prerelease GitHub release will be published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release information for `v2.5.0.SNAPSHOT` and clarified the `v2.4.0` entry.
  * Documented Compose startup and health-check behavior, including path validation, profile handling, strict execution, and failure reporting.
  * Clarified how failures affect JSON output.
  * Added regression coverage details for lifecycle and health-check scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->